### PR TITLE
Update swap_tags def

### DIFF
--- a/failover.py
+++ b/failover.py
@@ -79,7 +79,7 @@ def swap_tag(network_id):
                     network_tags[tag] = specific_tag
                 elif re.match(secondary_tag_regex, network_tags[tag]):
                     # removing -sec from the tag value
-                    specific_tag = str(network_tags[tag])[-4]
+                    specific_tag = str(network_tags[tag])[:-4]
                     network_tags[tag] = specific_tag
 
             print(network_tags)


### PR DESCRIPTION
elif re.match(secondary_tag_regex, network_tags[tag]):
# removing -sec from the tag value
specific_tag = str(network_tags[tag])[-4]
network_tags[tag] = specific_tag

The line "specific_tag = str(network_tags[tag])[-4]" should be replaced with "specific_tag = str(network_tags[tag])[:-4]"

If you use the scrip as it is now, instead of deleting the 4 last characters it will set "specific_tag" to be the 4th character from the end of the string - "-" in our case (*-sec).